### PR TITLE
Rendering Issues in Replay View on Android

### DIFF
--- a/Assets/PreviewTexture.renderTexture
+++ b/Assets/PreviewTexture.renderTexture
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!84 &8400000
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PreviewTexture
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 5
+  m_Width: 1920
+  m_Height: 1080
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 94
+  m_ColorFormat: 8
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 1
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2

--- a/Assets/PreviewTexture.renderTexture.meta
+++ b/Assets/PreviewTexture.renderTexture.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5cf7293dda184f74e920fa26c0430ab1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 8400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Prefabs/Plume-Player.prefab
+++ b/Assets/Runtime/Prefabs/Plume-Player.prefab
@@ -270,7 +270,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &3527861557537485353
 Transform:
   m_ObjectHideFlags: 0
@@ -1065,6 +1065,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   typeRegistryProvider: {fileID: 27516560266712775}
   loop: 0
+  previewRenderTexture: {fileID: 8400000, guid: 5cf7293dda184f74e920fa26c0430ab1, type: 2}
   freeCamera: {fileID: 5243149662805609015}
   topViewCamera: {fileID: 5720294478372019317}
   mainCamera: {fileID: 4958596500381266705}

--- a/Assets/Runtime/Scripts/RecordAssetBundle.cs
+++ b/Assets/Runtime/Scripts/RecordAssetBundle.cs
@@ -48,6 +48,11 @@ namespace PLUME
         private Object LoadCustomAsset(Type assetType, string assetPath, string assetName)
         {
             var assets = _assetBundle.LoadAssetWithSubAssets(assetPath, assetType);
+            if (assets == null || assets.Length == 0)
+            {
+                Debug.LogWarning($"Asset '{assetPath}' not found in asset bundle.");
+                return null;
+            }
             return assets.FirstOrDefault(asset => asset.name == assetName);
         }
 

--- a/Assets/Runtime/Scripts/RecordAssetBundle.cs
+++ b/Assets/Runtime/Scripts/RecordAssetBundle.cs
@@ -35,8 +35,6 @@ namespace PLUME
 
             var assetType = Type.GetType(assetTypeName) ?? typeof(Object);
 
-            Debug.Log($"'{assetType}' '{assetPath}' '{assetName}' '{assetSource}'");
-            
             var asset = assetSource switch
             {
                 "Custom" => LoadCustomAsset(assetType, assetPath, assetName),

--- a/Assets/Runtime/Scripts/Viewer/MainWindowPresenter.cs
+++ b/Assets/Runtime/Scripts/Viewer/MainWindowPresenter.cs
@@ -45,7 +45,7 @@ namespace PLUME.Viewer
             _mainWindowUI.PreviewRenderAspectRatio.RegisterCallback<NavigationMoveEvent>(OnPreviewRenderNavigationMove);
             _mainWindowUI.PreviewRenderAspectRatio.RegisterCallback<KeyDownEvent>(OnPreviewRenderKeyDown);
             _mainWindowUI.PreviewRender.style.backgroundImage =
-                Background.FromRenderTexture(player.PreviewRenderTexture);
+                Background.FromRenderTexture(player.previewRenderTexture);
 
             _mainWindowUI.Timeline.RegisterCallback<KeyDownEvent>(OnPlayPauseKeyDown);
             _mainWindowUI.PlayPauseButton.RegisterCallback<KeyDownEvent>(OnPlayPauseKeyDown);

--- a/Assets/Runtime/Scripts/Viewer/Player/Player.cs
+++ b/Assets/Runtime/Scripts/Viewer/Player/Player.cs
@@ -42,7 +42,7 @@ namespace PLUME.Viewer.Player
         private bool _isPlaying;
         private ulong _currentTimeNanoseconds;
 
-        public RenderTexture PreviewRenderTexture { get; private set; }
+        public RenderTexture previewRenderTexture;
 
         public event Action OnFinishLoading = delegate { };
 
@@ -81,11 +81,10 @@ namespace PLUME.Viewer.Player
                 transform.parent = null;
                 DontDestroyOnLoad(gameObject);
             }
-
-            PreviewRenderTexture = RenderTexture.GetTemporary(1920, 1080);
-            freeCamera.PreviewRenderTexture = PreviewRenderTexture;
-            topViewCamera.PreviewRenderTexture = PreviewRenderTexture;
-            mainCamera.PreviewRenderTexture = PreviewRenderTexture;
+            
+            freeCamera.PreviewRenderTexture = previewRenderTexture;
+            topViewCamera.PreviewRenderTexture = previewRenderTexture;
+            mainCamera.PreviewRenderTexture = previewRenderTexture;
             freeCamera.transform.position = new Vector3(-2.24f, 1.84f, 0.58f);
             freeCamera.transform.rotation = Quaternion.Euler(25f, -140f, 0f);
             topViewCamera.transform.position = new Vector3(0, 3.25f, -4);
@@ -242,7 +241,7 @@ namespace PLUME.Viewer.Player
         public void SetCurrentPreviewCamera(PreviewCamera camera)
         {
             var rt = RenderTexture.active;
-            RenderTexture.active = PreviewRenderTexture;
+            RenderTexture.active = previewRenderTexture;
             GL.Clear(true, true, Color.clear);
             RenderTexture.active = rt;
 
@@ -273,7 +272,6 @@ namespace PLUME.Viewer.Player
 
         public void OnDestroy()
         {
-            PreviewRenderTexture.Release();
             _recordLoader.Dispose();
         }
 

--- a/Assets/Runtime/Scripts/Viewer/Player/Player.cs
+++ b/Assets/Runtime/Scripts/Viewer/Player/Player.cs
@@ -360,7 +360,7 @@ namespace PLUME.Viewer.Player
 
         public float GetRecordAssetBundleLoadingProgress()
         {
-            return _bundleLoader.GetLoadingProgress();
+            return _bundleLoader?.GetLoadingProgress() ?? 0;
         }
 
         public void SetPlaySpeed(float playSpeed)

--- a/Assets/Scenes/PlayerScene.unity
+++ b/Assets/Scenes/PlayerScene.unity
@@ -147,9 +147,17 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1041767726375591474, guid: b4a12f1ba345b14438d4ad048811be15, type: 3}
+      propertyPath: PreviewRenderTexture
+      value: 
+      objectReference: {fileID: 8400000, guid: 5cf7293dda184f74e920fa26c0430ab1, type: 2}
     - target: {fileID: 1622235944094969762, guid: b4a12f1ba345b14438d4ad048811be15, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3688873362705555609, guid: b4a12f1ba345b14438d4ad048811be15, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3853190476271717280, guid: b4a12f1ba345b14438d4ad048811be15, type: 3}
       propertyPath: m_LocalPosition.x
@@ -206,10 +214,6 @@ PrefabInstance:
     - target: {fileID: 5635019901420886447, guid: b4a12f1ba345b14438d4ad048811be15, type: 3}
       propertyPath: defaultInteractionType
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6271649878948817840, guid: b4a12f1ba345b14438d4ad048811be15, type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7333346258209044708, guid: b4a12f1ba345b14438d4ad048811be15, type: 3}
       propertyPath: m_RequiresDepthTextureOption

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -26,9 +26,9 @@ MonoBehaviour:
   lightLayerName7: 
   m_StripDebugVariants: 1
   m_StripUnusedPostProcessingVariants: 0
-  m_StripUnusedVariants: 1
+  m_StripUnusedVariants: 0
   m_StripUnusedLODCrossFadeVariants: 1
-  m_StripScreenCoordOverrideVariants: 1
+  m_StripScreenCoordOverrideVariants: 0
   supportRuntimeDebugDisplay: 0
   m_ShaderVariantLogLevel: 0
   m_ExportShaderVariants: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -176,7 +176,7 @@ PlayerSettings:
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
-  stripEngineCode: 1
+  stripEngineCode: 0
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
   ForceInternetPermission: 0


### PR DESCRIPTION
# Fix: Rendering Issues in Replay View

This pull request resolves the rendering issues identified by @BergLucas.  
The problems were due to two main causes:

1. **Incorrect depth buffer configuration**
2. **Improperly loaded lightmaps**

![image](https://github.com/user-attachments/assets/bd036f0c-f402-4f6b-b15c-ce429513e57d)

---

## 🐛 Bug Fixes

### Lightmap Loading

The replay appeared completely black due to lightmaps not being loaded correctly:

![Lightmap Bug](https://github.com/user-attachments/assets/d03c76ec-c6db-4f35-8afe-7edb0e21f45b)

To help debug missing assets from the bundle (in this case the lightmaps), a log message was added:

![Missing Asset Log](https://github.com/user-attachments/assets/a2b4b365-85b3-451a-83dd-3e2798736cd9)

**Root cause:**  
The tutorial’s `record1.plm` and `record2.plm` used lightmaps generated by the Bakery plugin, which was later removed due to licensing restrictions.

**Fix:**  
Recording new record using the current tutorial project (with Unity’s built-in lightmaps) results in correct reference to the new lightmaps and thus a correct loading in the viewer.

### Depth Buffer

Even with valid lightmaps, depth rendering was incorrect — meshes were layered improperly:

![Depth Buffer Bug](https://github.com/user-attachments/assets/f265c796-18da-4f44-a71d-5ac29df3bc03)

**Root cause:**  
The issue stemmed from a `RenderTexture` created using [`RenderTexture.GetTemporary`](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/RenderTexture.GetTemporary.html) in [`Player.cs#L73`](https://github.com/cjaverliat/PLUME-Viewer-Android/blob/b0847ca31fa22caba339dca25863c573abbd4ffd/Runtime/Scripts/Viewer/Player/Player.cs#L73).  
This method reuses textures from a pool and, without explicitly set depth parameters, the reused texture had an incorrect depth buffer.

**Fix:**  
A dedicated render texture asset (`PreviewTexture.renderTexture`) was created and used consistently across the codebase. 2f2a0c87301c4a519a4f217e582a03268e207154

### Shader/Class Stripping

The build threw runtime errors due to stripped classes and shaders:

![Class Stripping](https://github.com/user-attachments/assets/243badfd-26bb-42e1-90b6-0fb66c42edff)

**Fixes:**
- Disabled [`PlayerSettings.stripEngineCode`](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/PlayerSettings-stripEngineCode.html) to prevent class stripping 7cedc0c78570fc4ba55b1850cd61222dd7f0427f

- Disabled shader stripping in URP settings `57e04bd0293741f7611cfeeea8417de21b086f10`

### NullReferenceException in the loading panel

**Issue:**  
A `NullReferenceException` occurred in `Player.cs` when `bundleLoader` was still null.

**Fix:**  
Added null-coalescing to default progress to `0` when `bundleLoader` is not available. f417e5549d52ecc875dd4c52368a6d84a5e3c61e

---

## 🧹 Code Cleanup

- Removed excessive debug logging from `RecordAssetBundle.cs` f5b8a48a62e7005b5469bd645458644e892b4541

- Added warning logs for missing assets in the bundle 761008b9abd02e4c71e9d7a49939947dd99f9e21

---

## ✅ Final Result

Rendering now works as expected:

![Correct Rendering](https://github.com/user-attachments/assets/26be3b68-4b4c-4dd8-8853-97c87f10ac19)

_Screenshots from a Google Pixel 6A_